### PR TITLE
 - default `process.env.NODE_ENV` to `production`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project is following [Semantic Versioning](http://semver.org)
 
 ## [Unreleased][]
 
+## [0.1.3][] - 2018-02-09
+
+ - default `process.env.NODE_ENV` to `production` when packaging the app for distribution with webpack  
+
 ## [0.1.2][] - 2017-12-13
 
 ### Changed  
@@ -23,7 +27,8 @@ This project is following [Semantic Versioning](http://semver.org)
 
  - initial release
  
-[Unreleased]: https://github.com/DeskproApps/fullstory/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/DeskproApps/fullstory/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/DeskproApps/fullstory/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/DeskproApps/fullstory/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/DeskproApps/fullstory/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/DeskproApps/fullstory/compare/master...v0.1.0

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskproapps/fullstory",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskproapps/fullstory",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "This application adds a sidebar that lets you see a ticket owner's list of Fullstory sessions",
   "main": "lib/main/javascript/index.js",
   "scripts": {

--- a/src/webpack/webpack.config-distribution.js
+++ b/src/webpack/webpack.config-distribution.js
@@ -5,6 +5,7 @@ module.exports = function (env) {
 
   const PROJECT_ROOT_PATH = env && env.DP_PROJECT_ROOT ? env.DP_PROJECT_ROOT : path.resolve(__dirname, '../../');
   const DEBUG = env && env.NODE_ENV === 'development';
+  const ENVIRONMENT =  env && env.NODE_ENV ? env.NODE_ENV : 'production';
 
   const buildManifest = new dpat.BuildManifest(
     PROJECT_ROOT_PATH,
@@ -67,7 +68,8 @@ module.exports = function (env) {
 
       new dpat.Webpack.DefinePlugin({
         DEBUG: DEBUG,
-        DPAPP_MANIFEST: JSON.stringify(buildManifest.getContent())
+        DPAPP_MANIFEST: JSON.stringify(buildManifest.getContent()),
+        'process.env.NODE_ENV': JSON.stringify(ENVIRONMENT)
       }),
 
       // for stable builds, in production we replace the default module index with the module's content hashe


### PR DESCRIPTION
 - default `process.env.NODE_ENV` to `production` when packaging the app for distribution with webpack